### PR TITLE
[Device] Add OpenUriEx player method v2

### DIFF
--- a/doc/server/dbus/API.txt
+++ b/doc/server/dbus/API.txt
@@ -256,11 +256,18 @@ interface.  The main points of interest are noted below:
 |                     |        |    | channel.                                 |
 -------------------------------------------------------------------------------|
 
-- A new method has been added, it is described below:
+- new methods have been added, they are described below:
 
 GotoTrack(u TrackNumber) -> void
 
 Performs a seek operation to the specified track number.
+
+
+OpenUriEx(s Uri, s Metadata) -> void
+
+Same as the OpenUri method of the org.mpris.MediaPlayer2.Player MPRIS2 standard
+interface, with an additional parameter Metadata to specify the DIDL-Lite XML
+description of the item to be opened.
 
 
 org.mpris.MediaPlayer2.TrackList and org.mpris.MediaPlayer2.Playlists

--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -2264,8 +2264,10 @@ void dlr_device_open_uri(dlr_device_t *device, dlr_task_t *task,
 	dlr_device_context_t *context;
 	dlr_async_task_t *cb_data = (dlr_async_task_t *)task;
 	dlr_task_open_uri_t *open_uri_data = &task->ut.open_uri;
+	gchar *metadata = open_uri_data->metadata;
 
 	DLEYNA_LOG_INFO("URI: %s", open_uri_data->uri);
+	DLEYNA_LOG_INFO("METADATA: %s", metadata ? metadata : "Not provided");
 
 	context = dlr_device_get_context(device);
 	cb_data->cb = cb;
@@ -2289,7 +2291,8 @@ void dlr_device_open_uri(dlr_device_t *device, dlr_task_t *task,
 						 "CurrentURI", G_TYPE_STRING,
 						 open_uri_data->uri,
 						 "CurrentURIMetaData",
-						 G_TYPE_STRING, "",
+						 G_TYPE_STRING,
+						 metadata ? metadata : "",
 						 NULL);
 }
 

--- a/libdleyna/renderer/server.c
+++ b/libdleyna/renderer/server.c
@@ -65,6 +65,7 @@
 #define DLR_INTERFACE_PATH "Path"
 #define DLR_INTERFACE_URI "Uri"
 #define DLR_INTERFACE_ID "Id"
+#define DLR_INTERFACE_METADATA "Metadata"
 
 #define DLR_INTERFACE_CHANGED_PROPERTIES "changed_properties"
 #define DLR_INTERFACE_INVALIDATED_PROPERTIES "invalidated_properties"
@@ -89,6 +90,7 @@
 #define DLR_INTERFACE_PAUSE "Pause"
 #define DLR_INTERFACE_STOP "Stop"
 #define DLR_INTERFACE_OPEN_URI "OpenUri"
+#define DLR_INTERFACE_OPEN_URI_EX "OpenUriEx"
 #define DLR_INTERFACE_SEEK "Seek"
 #define DLR_INTERFACE_SET_POSITION "SetPosition"
 #define DLR_INTERFACE_GOTO_TRACK "GotoTrack"
@@ -196,6 +198,12 @@ static const gchar g_server_introspection[] =
 	"    </method>"
 	"    <method name='"DLR_INTERFACE_OPEN_URI"'>"
 	"      <arg type='s' name='"DLR_INTERFACE_URI"'"
+	"           direction='in'/>"
+	"    </method>"
+	"    <method name='"DLR_INTERFACE_OPEN_URI_EX"'>"
+	"      <arg type='s' name='"DLR_INTERFACE_URI"'"
+	"           direction='in'/>"
+	"      <arg type='s' name='"DLR_INTERFACE_METADATA"'"
 	"           direction='in'/>"
 	"    </method>"
 	"    <method name='"DLR_INTERFACE_SEEK"'>"
@@ -743,6 +751,8 @@ static void prv_dlr_player_method_call(dleyna_connector_id_t conn,
 		task = dlr_task_previous_new(invocation, object);
 	else if (!strcmp(method, DLR_INTERFACE_OPEN_URI))
 		task = dlr_task_open_uri_new(invocation, object, parameters);
+	else if (!strcmp(method, DLR_INTERFACE_OPEN_URI_EX))
+		task = dlr_task_open_uri_ex_new(invocation, object, parameters);
 	else if (!strcmp(method, DLR_INTERFACE_SEEK))
 		task = dlr_task_seek_new(invocation, object, parameters);
 	else if (!strcmp(method, DLR_INTERFACE_SET_POSITION))

--- a/libdleyna/renderer/task.c
+++ b/libdleyna/renderer/task.c
@@ -93,6 +93,7 @@ static void prv_dlr_task_delete(dlr_task_t *task)
 		break;
 	case DLR_TASK_OPEN_URI:
 		g_free(task->ut.open_uri.uri);
+		g_free(task->ut.open_uri.metadata);
 		break;
 	case DLR_TASK_HOST_URI:
 	case DLR_TASK_REMOVE_URI:
@@ -254,6 +255,24 @@ dlr_task_t *dlr_task_open_uri_new(dleyna_connector_msg_id_t invocation,
 
 	g_variant_get(parameters, "(s)", &task->ut.open_uri.uri);
 	g_strstrip(task->ut.open_uri.uri);
+
+	task->ut.open_uri.metadata = NULL;
+
+	return task;
+}
+
+dlr_task_t *dlr_task_open_uri_ex_new(dleyna_connector_msg_id_t invocation,
+				     const gchar *path, GVariant *parameters)
+{
+	dlr_task_t *task;
+
+	task = prv_device_task_new(DLR_TASK_OPEN_URI, invocation, path,
+				   NULL);
+
+	g_variant_get(parameters, "(ss)",
+		      &task->ut.open_uri.uri, &task->ut.open_uri.metadata);
+	g_strstrip(task->ut.open_uri.uri);
+	g_strstrip(task->ut.open_uri.metadata);
 
 	return task;
 }

--- a/libdleyna/renderer/task.h
+++ b/libdleyna/renderer/task.h
@@ -75,6 +75,7 @@ struct dlr_task_set_prop_t_ {
 typedef struct dlr_task_open_uri_t_ dlr_task_open_uri_t;
 struct dlr_task_open_uri_t_ {
 	gchar *uri;
+	gchar *metadata;
 };
 
 typedef struct dlr_task_seek_t_ dlr_task_seek_t;
@@ -154,6 +155,9 @@ dlr_task_t *dlr_task_goto_track_new(dleyna_connector_msg_id_t invocation,
 
 dlr_task_t *dlr_task_open_uri_new(dleyna_connector_msg_id_t invocation,
 				  const gchar *path, GVariant *parameters);
+
+dlr_task_t *dlr_task_open_uri_ex_new(dleyna_connector_msg_id_t invocation,
+				     const gchar *path, GVariant *parameters);
 
 dlr_task_t *dlr_task_host_uri_new(dleyna_connector_msg_id_t invocation,
 				  const gchar *path, const gchar *sender,

--- a/test/dbus/rendererconsole.py
+++ b/test/dbus/rendererconsole.py
@@ -104,6 +104,9 @@ class Renderer(object):
     def open_uri(self, uri):
         self.__playerIF.OpenUri(uri)
 
+    def open_uri_ex(self, uri, metadata):
+        self.__playerIF.OpenUriEx(uri, metadata)
+
     def previous(self):
         self.__playerIF.Previous()
 


### PR DESCRIPTION
added as recommended by the first review:
- strip metadata in the same way as it is done for the uri.
- I've kept the task->ut.open_uri.metadata = NULL; initialization even if it is not necessary for a better reading and understanding of the code, this field being not used in this context.

---
- Add a new player interface method OpenUriEx, which is the same as
  the existing OpenUri one, with an additional metadata parameter to pass
  the URI description information in DIDL-Lite XML format.
- Documentation updated.
- Renderer Console python test application updated.
- Fix issue: https://github.com/01org/dleyna-renderer/issues/25

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
