### PR TITLE
[Doc] add with-ua-prefix doc to README

### DIFF
--- a/README
+++ b/README
@@ -88,3 +88,11 @@ Set the IPC mechanism to be used.
 
 This option is disabled by default. To enable use --enable-lib-only.
 When enabled, only the libdleyna-renderer library is built.
+
+--with-ua-prefix
+
+This option allows to add a prefix to the SOUP session user agent.
+As example, if the user agent string is: dLeyna/0.0.1 GUPnP/0.19.4 DLNADOC/1.50
+then with --with-ua-prefix=MyPrefix, the user agent value will be:
+MyPrefix dLeyna/0.0.1 GUPnP/0.19.4 DLNADOC/1.50
+ 


### PR DESCRIPTION
- Add missing with-ua-prefix option doc to the README.
- Fix issue https://github.com/01org/dleyna-renderer/issues/41

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
