### PR TITLE
[Bug] Fix Blatant memory leak in dlr_device_new

### DIFF
--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -734,7 +734,7 @@ dlr_device_t *dlr_device_new(
 			const dleyna_connector_dispatch_cb_t *dispatch_table,
 			const dleyna_task_queue_key_t *queue_id)
 {
-	dlr_device_t *dev = g_new0(dlr_device_t, 1);
+	dlr_device_t *dev;
 	prv_new_device_ct_t *priv_t;
 	gchar *new_path;
 	dlr_device_context_t *context;


### PR DESCRIPTION
- In function dlr_device_new(), the variable dev is initialized
  twice. Remove redundant first dev variable initialization.
- Fix issue: https://github.com/01org/dleyna-renderer/issues/36

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
