### PR TITLE
[Device] Add X_DLNA_PS transport action support

### DIFF
--- a/libdleyna/renderer/device.h
+++ b/libdleyna/renderer/device.h
@@ -73,7 +73,11 @@ struct dlr_device_t_ {
 	guint timeout_id;
 	guint max_volume;
 	GPtrArray *transport_play_speeds;
+	GPtrArray *dlna_transport_play_speeds;
+	GVariant *mpris_transport_play_speeds;
 	gchar *rate;
+	double min_rate;
+	double max_rate;
 };
 
 dlr_device_t *dlr_device_new(


### PR DESCRIPTION
- Add the X_DLNA_PS transport action support to allow the
  playspeeds provided by the renderer once we have provided it a
  URI (SetAVTransportURI()) in addition to the renderer default
  playspeeds retrieved via the introspection.
  MINIMUM_RATE, MAXIMUM_RATE and TRANSPORT_PLAY_SPEEDS properties
  will be upddated.

when SetAVTransportURI() action is called, MINIMUM_RATE,
MAXIMUM_RATE and TRANSPORT_PLAY_SPEEDS properties will be reset
with the renderer default playspeeds.
- The renderer default playspeeds are stored in the dlr_device_t_
  structure to be re-used without having to be re-computed.
- When the application set the property RATE, the new rate value
  is checked with either the renderer default allowed playspeeds or
  the X_DLNA_PS allowed playspeeds depending on the availability of
  the X_DLNA_PS.
- We now emit a property changed signal when application set the
  DLR_INTERFACE_PROP_MINIMUM_RATE property with a value not equal
  to the current one.
- For the parsing of the action string containing the X_DLNA_PS
  content, thanks to regexp API, the sequence "\," are replaced
  by "_" ("\," is used to separated the X_DLNA_PS speeds),
  then the action string is splitted by "," to separate
  each actions token. For getting the X_DLNA_PS playspeeds we then
  just have to split the string with "_"

action string = Play,Stop,Seek,X_DLNA_PS=-8\,2\,4\,8

Signed-off-by: Christophe Guiraud christophe.guiraud@intel.com
