### PR TITLE
[Bug] Add a Rescan method to Manager interface : Fix Issue #2 

### DIFF
--- a/doc/server/dbus/API.txt
+++ b/doc/server/dbus/API.txt
@@ -63,6 +63,11 @@ method if they intend to keep running but they have no immediate plans
 to invoke any of dleyna-renderer-service's methods.  This allows
 dleyna-renderer-service to quit, freeing up system resources.
 
+Rescan()
+
+Calls a rescan to be performed by gssdp library to make sure every server is
+still alive. Every server that hasn't responded after a certain amount of
+time (see gssdp_resource_browser_rescan() code) is considered as unavailable.
 
 Signals:
 ---------

--- a/libdleyna/renderer/upnp.c
+++ b/libdleyna/renderer/upnp.c
@@ -47,6 +47,7 @@ struct dlr_upnp_t_ {
 	GHashTable *server_uc_map;
 	guint counter;
 	dlr_host_service_t *host_service;
+	GSList *browsers;
 };
 
 /* Private structure used in service task */
@@ -292,6 +293,7 @@ static void prv_on_context_available(GUPnPContextManager *context_manager,
 	g_signal_connect(cp, "device-proxy-unavailable",
 			 G_CALLBACK(prv_server_unavailable_cb), upnp);
 
+	upnp->browsers = g_slist_prepend(upnp->browsers, cp);
 	gssdp_resource_browser_set_active(GSSDP_RESOURCE_BROWSER(cp), TRUE);
 	gupnp_context_manager_manage_control_point(upnp->context_manager, cp);
 	g_object_unref(cp);
@@ -337,6 +339,11 @@ void dlr_upnp_delete(dlr_upnp_t *upnp)
 
 		g_free(upnp);
 	}
+}
+
+GSList *dlr_upnp_get_browsers(dlr_upnp_t *upnp)
+{
+	return upnp->browsers;
 }
 
 GVariant *dlr_upnp_get_server_ids(dlr_upnp_t *upnp)

--- a/libdleyna/renderer/upnp.h
+++ b/libdleyna/renderer/upnp.h
@@ -47,6 +47,8 @@ dlr_upnp_t *dlr_upnp_new(dleyna_connector_id_t connection,
 
 void dlr_upnp_delete(dlr_upnp_t *upnp);
 
+GSList *dlr_upnp_get_browsers(dlr_upnp_t *upnp);
+
 GVariant *dlr_upnp_get_server_ids(dlr_upnp_t *upnp);
 
 GHashTable *dlr_upnp_get_server_udn_map(dlr_upnp_t *upnp);

--- a/test/dbus/rendererconsole.py
+++ b/test/dbus/rendererconsole.py
@@ -166,6 +166,8 @@ class Manager(object):
     def release(self):
         self.__manager.Release()
 
+    def rescan(self):
+        self.__manager.Rescan()
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
- Add a new field (browsers) in struct dlr_upnp_t_ to keep track of
  the gupnp_control_points created for each network interface since
  there is no other way to retrieve them.
- Documentation updated.

Signed-off-by: Sébastien Bianti sebastien.bianti@linux.intel.com
