### PR TITLE
[RendererConsole] Added methods for creating renderers

### DIFF
--- a/test/dbus/rendererconsole.py
+++ b/test/dbus/rendererconsole.py
@@ -146,6 +146,25 @@ class Manager(object):
         self.update_renderers()
         return self.__renderers
 
+    def renderer_from_name(self, friendly_name):
+        retval = None
+        for i in self.__manager.GetServers():
+            renderer = Renderer(i)
+            renderer_name = renderer.get_prop("FriendlyName").lower()
+            if renderer_name.find(friendly_name.lower()) != -1:
+                retval = renderer
+                break
+        return retval
+
+    def renderer_from_udn(self, udn):
+        retval = None
+        for i in self.__manager.GetServers():
+            renderer = Renderer(i)
+            if renderer.get_prop("UDN") == udn:
+                retval = renderer
+                break
+        return retval
+
     def renderers(self):
         self.update_renderers()
 


### PR DESCRIPTION
Two new methods have been added to the Manager class, renderer_from_name and
renderer_from_udn.  These methods can be used to construct Renderer objects
from UDNs or friendly names, which is typically easier than using
the d-Bus path, which is long and changes from one invocation of
dLeyna-renderer to the next.

Signed-off-by: Mark Ryan mark.d.ryan@intel.com
