### PR TITLE
[Device] Fix a GetIcon() crash case

### DIFF
--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -2786,6 +2786,7 @@ void dlr_device_get_icon(dlr_device_t *device, dlr_task_t *task,
 				      G_CALLBACK(prv_get_icon_cancelled),
 				      download, NULL);
 
+	g_object_ref(download->msg);
 	soup_session_queue_message(download->session, download->msg,
 				   prv_get_icon_session_cb, download);
 


### PR DESCRIPTION
Fix issue #84
