### PR TITLE
[Device] Add an extra mimetype parameter to GetIcon()

### DIFF
--- a/doc/server/dbus/API.txt
+++ b/doc/server/dbus/API.txt
@@ -197,12 +197,12 @@ Cancel() -> void
 
 Cancels all requests a client has outstanding on that server.
 
-GetIcon(s Resolution) -> (ay Data, s MimeType)
+GetIcon(s RequestedMimeType, s Resolution) -> (ay Bytes, s MimeType)
 
 Returns the device icon bytes and mime type according to
-the Resolution parameter.
-The Resolution parameter is currently reserved for future use
-and should be set as an empty string.
+the RequestedMimeType and Resolution parameters.
+Both RequestedMimeType and Resolution parameters are currently
+reserved for future use and should be set as an empty string.
 
 org.mpris.MediaPlayer2
 ----------------------

--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -2758,7 +2758,7 @@ void dlr_device_get_icon(dlr_device_t *device, dlr_task_t *task,
 	url = gupnp_device_info_get_icon_url(info, NULL, -1, -1, -1, FALSE,
 					     &device->icon.mime_type, NULL,
 					     NULL, NULL);
-	if (url == NULL || *url == 0) {
+	if (url == NULL) {
 		cb_data->error = g_error_new(DLEYNA_SERVER_ERROR,
 					     DLEYNA_ERROR_NOT_SUPPORTED,
 					     "No icon available");
@@ -2777,6 +2777,7 @@ void dlr_device_get_icon(dlr_device_t *device, dlr_task_t *task,
 					     DLEYNA_ERROR_BAD_RESULT,
 					     "Invalid URL %s", url);
 		prv_free_download_info(download);
+		g_free(url);
 
 		goto end;
 	}
@@ -2789,6 +2790,8 @@ void dlr_device_get_icon(dlr_device_t *device, dlr_task_t *task,
 	g_object_ref(download->msg);
 	soup_session_queue_message(download->session, download->msg,
 				   prv_get_icon_session_cb, download);
+
+	g_free(url);
 
 	return;
 

--- a/libdleyna/renderer/server.c
+++ b/libdleyna/renderer/server.c
@@ -101,7 +101,7 @@
 #define DLR_INTERFACE_RESOLUTION "Resolution"
 #define DLR_INTERFACE_ICON_BYTES "Bytes"
 #define DLR_INTERFACE_MIME_TYPE "MimeType"
-
+#define DLR_INTERFACE_REQ_MIME_TYPE "RequestedMimeType"
 
 typedef struct dlr_context_t_ dlr_context_t;
 struct dlr_context_t_ {
@@ -280,6 +280,8 @@ static const gchar g_server_introspection[] =
 	"    <method name='"DLR_INTERFACE_CANCEL"'>"
 	"    </method>"
 	"    <method name='"DLR_INTERFACE_GET_ICON"'>"
+	"      <arg type='s' name='"DLR_INTERFACE_REQ_MIME_TYPE"'"
+	"           direction='in'/>"
 	"      <arg type='s' name='"DLR_INTERFACE_RESOLUTION"'"
 	"           direction='in'/>"
 	"      <arg type='ay' name='"DLR_INTERFACE_ICON_BYTES"'"

--- a/libdleyna/renderer/task.c
+++ b/libdleyna/renderer/task.c
@@ -112,6 +112,7 @@ static void prv_dlr_task_delete(dlr_task_t *task)
 		g_free(task->ut.host_uri.client);
 		break;
 	case DLR_TASK_GET_ICON:
+		g_free(task->ut.get_icon.mime_type);
 		g_free(task->ut.get_icon.resolution);
 		break;
 	default:
@@ -333,7 +334,8 @@ dlr_task_t *dlr_task_get_icon_new(dleyna_connector_msg_id_t invocation,
 				   "(@ays)");
 	task->multiple_retvals = TRUE;
 
-	g_variant_get(parameters, "(s)", &task->ut.get_icon.resolution);
+	g_variant_get(parameters, "(ss)", &task->ut.get_icon.mime_type,
+		      &task->ut.get_icon.resolution);
 
 	return task;
 }

--- a/libdleyna/renderer/task.h
+++ b/libdleyna/renderer/task.h
@@ -94,6 +94,7 @@ struct dlr_task_host_uri_t_ {
 
 typedef struct dlr_task_get_icon_t_ dlr_task_get_icon_t;
 struct dlr_task_get_icon_t_ {
+	gchar *mime_type;
 	gchar *resolution;
 };
 

--- a/test/dbus/rendererconsole.py
+++ b/test/dbus/rendererconsole.py
@@ -123,8 +123,8 @@ class Renderer(object):
     def stop(self):
         self.__playerIF.Stop()
 
-    def print_icon(self, resolution):
-        bytes, mime = self.__deviceIF.GetIcon(resolution)
+    def print_icon(self, mime_type, resolution):
+        bytes, mime = self.__deviceIF.GetIcon(mime_type, resolution)
         print "Icon mime type: " + mime
 
 # Push Host methods
@@ -223,4 +223,4 @@ if __name__ == "__main__":
             print("¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯¯" + (len(name) + len(if_name)) * "¯")
             renderer.print_props(if_name)
 
-        renderer.print_icon("")
+        renderer.print_icon("", "")


### PR DESCRIPTION
- Add an extra parameter to GetIcon() to match the same function prototype as for dleyna-server
- Fix a memory leak
