### PR TITLE
[Device] GetAll: do not fail if the DMR returns an error for GetPositionInfo

### DIFF
--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -1613,6 +1613,7 @@ static void prv_get_position_info_cb(GUPnPServiceProxy *proxy,
 			/* Do not fail, just remove the property */
 			g_hash_table_remove(cb_data->device->props.player_props,
 					    DLR_INTERFACE_PROP_POSITION);
+			goto end;
 		} else {
 			message = (error != NULL) ? error->message :
 							"Invalid result";
@@ -1621,7 +1622,7 @@ static void prv_get_position_info_cb(GUPnPServiceProxy *proxy,
 						DLEYNA_ERROR_OPERATION_FAILED,
 						"GetPositionInfo operation failed: %s",
 						message);
-			goto on_error;
+			goto end;
 		}
 	}
 
@@ -1639,7 +1640,7 @@ static void prv_get_position_info_cb(GUPnPServiceProxy *proxy,
 	g_variant_unref(changed_props);
 	g_variant_builder_unref(changed_props_vb);
 
-on_error:
+end:
 
 	if (error != NULL)
 		g_error_free(error);


### PR DESCRIPTION
Fix issue #92.

When calling GetAll(), if the DMR returns an error for GetPositionInfo when stopped, we don't fail anymore.
The property is simply removed from the hashtable. 
