### PR TITLE
Uid

### DIFF
--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -816,6 +816,52 @@ void dlr_device_construct(
 	DLEYNA_LOG_DEBUG("Exit");
 }
 
+static char *prv_convert_udn_to_path(const char *udn)
+{
+	char *uuid;
+	size_t len;
+	size_t dest_len;
+	size_t i;
+
+	/* This function will generate a valid dbus path from the udn
+	 * We are not going to check the UDN validity. We will try to
+	 * convert it anyway. To avoid any security problem, we will
+	 * check some limits and possibily return only a partial
+	 * UDN. For a better understanding, a valid UDN should be:
+	 * UDN = "uuid:4Hex-2Hex-2Hex-Hex-Hex-6Hex"
+	 *
+	 * The convertion rules are:
+	 * 1 - An invalid char will be escaped using its hexa representation
+	 *     prefixed with '_': Ex ':' -> '_3A'
+	 * 2 - The max size of the converted UDN can be 3 times the original
+	 *     size (if all char are not dbus compliant).
+	 *     The max size of a dbus path is an UINT32: G_MAXUINT32
+	 *     We will limit the of the converted string size to G_MAXUINT32 / 2
+	 *     otherwise we will never have space to generate object path.
+	 */
+
+	len = strlen(udn);
+	dest_len = MIN(len * 3, G_MAXUINT32 / 2);
+
+	uuid = g_malloc(dest_len + 1);
+	i = 0;
+
+	while (*udn && (i < dest_len))
+	{
+		if (g_ascii_isalnum(*udn) || (*udn == '_'))
+			uuid[i++] = *udn;
+		else
+			i += g_snprintf(uuid + i, dest_len + 1,"_%02x", *udn);
+
+		udn++;
+	}
+
+
+	uuid[i]=0;
+
+	return uuid;
+}
+
 dlr_device_t *dlr_device_new(
 			dleyna_connector_id_t connection,
 			GUPnPDeviceProxy *proxy,
@@ -831,15 +877,11 @@ dlr_device_t *dlr_device_new(
 
 	DLEYNA_LOG_DEBUG("New Device on %s", ip_address);
 
-	/* Strip 'uuid:' string prefix if exists and replace unauthorized
-	 * dbus path char from uuid string */
-	uuid = strchr(udn, ':');
-	uuid = g_strdup(uuid ? uuid + 1 : udn);
-	uuid = g_strdelimit(uuid, "-", '_');
-
+	uuid = prv_convert_udn_to_path(udn);
 	new_path = g_strdup_printf("%s/%s", DLEYNA_SERVER_PATH, uuid);
-	DLEYNA_LOG_DEBUG("Server Path %s", new_path);
 	g_free(uuid);
+
+	DLEYNA_LOG_DEBUG("Server Path %s", new_path);
 
 	dev = g_new0(dlr_device_t, 1);
 

--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -820,18 +820,26 @@ dlr_device_t *dlr_device_new(
 			dleyna_connector_id_t connection,
 			GUPnPDeviceProxy *proxy,
 			const gchar *ip_address,
-			guint counter,
+			const char *udn,
 			const dleyna_connector_dispatch_cb_t *dispatch_table,
 			const dleyna_task_queue_key_t *queue_id)
 {
 	dlr_device_t *dev;
 	gchar *new_path;
+	gchar *uuid;
 	dlr_device_context_t *context;
 
 	DLEYNA_LOG_DEBUG("New Device on %s", ip_address);
 
-	new_path = g_strdup_printf("%s/%u", DLEYNA_SERVER_PATH, counter);
+	/* Strip 'uuid:' string prefix if exists and replace unauthorized
+	 * dbus path char from uuid string */
+	uuid = strchr(udn, ':');
+	uuid = g_strdup(uuid ? uuid + 1 : udn);
+	uuid = g_strdelimit(uuid, "-", '_');
+
+	new_path = g_strdup_printf("%s/%s", DLEYNA_SERVER_PATH, uuid);
 	DLEYNA_LOG_DEBUG("Server Path %s", new_path);
+	g_free(uuid);
 
 	dev = g_new0(dlr_device_t, 1);
 

--- a/libdleyna/renderer/device.h
+++ b/libdleyna/renderer/device.h
@@ -101,7 +101,7 @@ dlr_device_t *dlr_device_new(
 			dleyna_connector_id_t connection,
 			GUPnPDeviceProxy *proxy,
 			const gchar *ip_address,
-			guint counter,
+			const char *udn,
 			const dleyna_connector_dispatch_cb_t *dispatch_table,
 			const dleyna_task_queue_key_t *queue_id);
 

--- a/libdleyna/renderer/upnp.c
+++ b/libdleyna/renderer/upnp.c
@@ -45,7 +45,6 @@ struct dlr_upnp_t_ {
 	void *user_data;
 	GHashTable *server_udn_map;
 	GHashTable *server_uc_map;
-	guint counter;
 	dlr_host_service_t *host_service;
 };
 
@@ -186,14 +185,10 @@ static void prv_server_available_cb(GUPnPControlPoint *cp,
 		queue_id = prv_create_device_queue(&priv_t);
 
 		device = dlr_device_new(upnp->connection, proxy, ip_address,
-					upnp->counter,
-					upnp->interface_info,
-					queue_id);
+					udn, upnp->interface_info, queue_id);
 
 		prv_update_device_context(priv_t, upnp, udn, device, ip_address,
 					  queue_id);
-
-		upnp->counter++;
 	} else {
 		DLEYNA_LOG_DEBUG("Device Found");
 

--- a/libdleyna/renderer/upnp.c
+++ b/libdleyna/renderer/upnp.c
@@ -161,8 +161,8 @@ static void prv_server_available_cb(GUPnPControlPoint *cp,
 
 	udn = gupnp_device_info_get_udn((GUPnPDeviceInfo *)proxy);
 
-	ip_address = gupnp_context_get_host_ip(
-		gupnp_control_point_get_context(cp));
+	ip_address = gssdp_client_get_host_ip(
+		GSSDP_CLIENT(gupnp_control_point_get_context(cp)));
 
 	if (!udn || !ip_address)
 		goto on_error;


### PR DESCRIPTION
Currently DMRes are identified by sequential integers which depends on the order they're first seen by dleyna-renderer (eg. /com/intel/dLeynaRenderer/server/2).

This means that it will be impossible to keep persistent references to objects across DMR or dleyna-renderer restarts, as media items will have paths like /com/intel/dLeynaRenderer/server/2/3034306130393764373063393261313636623936616133623835663332306334.

To address this we could use the udn as stable server identifier, eg. /com/intel/dLeynaRenderer/server/uuid/6da19ece-c964-4094-a2bd-84249e8c7da6.

To also allow for more compact and closer to the original representation of the media item identifiers something like tp_escape_as_identifier() could be employed, escaping only invalid characters instead of always doubling the required string length as done by prv_id_to_object_name().

(Text based on #114 and 01org/dleyna-server#119)