### PR TITLE
[Memory Leak] Partial fix for bug 129

### DIFF
--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -2252,7 +2252,7 @@ static void prv_update_device_props(GUPnPDeviceInfo *proxy, GHashTable *props)
 	GVariant *val;
 	gchar *str;
 
-	(void ) prv_update_prop_dlna_device_classes(proxy, props);
+	(void) prv_update_prop_dlna_device_classes(proxy, props);
 
 	val = g_variant_ref_sink(g_variant_new_string(
 				gupnp_device_info_get_device_type(proxy)));


### PR DESCRIPTION
https://github.com/01org/dleyna-renderer/issues/129

This commit attempts to partially fix bug 129.  It cannot be
completely fixed at the moment due to a bug in GUPnP.

https://bugzilla.gnome.org/show_bug.cgi?id=708751

At least we're freeing the list now, if not the strings that it
contains.  Also, to reduce the effect of the memory leak, this
commit ensures that it only happens once per renderer rather than
once each time we receive an event from a renderer.  The assumption
is that a device will not dynamically change the DLNA classes that
it supports.

Signed-off-by: Mark Ryan mark.d.ryan@intel.com
