### PR TITLE
upnp: use port setting when creating GUPnPContextManager

### DIFF
--- a/libdleyna/renderer/dleyna-renderer-service.conf.in
+++ b/libdleyna/renderer/dleyna-renderer-service.conf.in
@@ -15,6 +15,10 @@ connector-name=@with_connector_name@
 # Source port for SSDP messages
 #port=4321
 
+# Port for Push host fileserver
+# If unset, a random available port will be used.
+#push-host-port=5432
+
 # Log configuration options
 [log]
 

--- a/libdleyna/renderer/host-service.h
+++ b/libdleyna/renderer/host-service.h
@@ -25,7 +25,8 @@
 
 typedef struct dlr_host_service_t_ dlr_host_service_t;
 
-void dlr_host_service_new(dlr_host_service_t **host_service);
+void dlr_host_service_new(dlr_host_service_t **host_service,
+			  guint port);
 
 gchar *dlr_host_service_add(dlr_host_service_t *host_service,
 			    const gchar *device_if, const gchar *client,

--- a/libdleyna/renderer/server.c
+++ b/libdleyna/renderer/server.c
@@ -1127,6 +1127,7 @@ static gboolean prv_control_point_start_service(
 	if (g_context.dlr_id[DLR_MANAGER_INTERFACE_MANAGER]) {
 		g_context.upnp = dlr_upnp_new(connection,
 					     dleyna_settings_port(g_context.settings),
+					     dleyna_settings_push_host_port(g_context.settings),
 					     g_server_vtables,
 					     prv_found_media_server,
 					     prv_lost_media_server);

--- a/libdleyna/renderer/upnp.c
+++ b/libdleyna/renderer/upnp.c
@@ -362,6 +362,7 @@ static void prv_on_context_available(GUPnPContextManager *context_manager,
 
 dlr_upnp_t *dlr_upnp_new(dleyna_connector_id_t connection,
 			 guint port,
+			 guint push_host_port,
 			 const dleyna_connector_dispatch_cb_t *dispatch_table,
 			 dlr_upnp_callback_t found_server,
 			 dlr_upnp_callback_t lost_server)
@@ -386,7 +387,7 @@ dlr_upnp_t *dlr_upnp_new(dleyna_connector_id_t connection,
 			 G_CALLBACK(prv_on_context_available),
 			 upnp);
 
-	dlr_host_service_new(&upnp->host_service);
+	dlr_host_service_new(&upnp->host_service, push_host_port);
 
 	return upnp;
 }

--- a/libdleyna/renderer/upnp.h
+++ b/libdleyna/renderer/upnp.h
@@ -43,6 +43,7 @@ typedef void (*dlr_upnp_task_complete_t)(dlr_task_t *task, GError *error);
 
 dlr_upnp_t *dlr_upnp_new(dleyna_connector_id_t connection,
 			 uint port,
+			 uint push_host_port,
 			 const dleyna_connector_dispatch_cb_t *dispatch_table,
 			 dlr_upnp_callback_t found_server,
 			 dlr_upnp_callback_t lost_server);


### PR DESCRIPTION
Signed-off-by: Jussi Kukkonen jussi.kukkonen@intel.com

See https://github.com/01org/dleyna-core/pull/40 for the dependency.
