### PR TITLE
daemon: use GLib signal handling

### DIFF
--- a/server/daemon.c
+++ b/server/daemon.c
@@ -22,82 +22,30 @@
  */
 
 #include <glib.h>
-#include <sys/signalfd.h>
+#include <glib-unix.h>
 
 #include <libdleyna/core/main-loop.h>
 #include <libdleyna/renderer/control-point-renderer.h>
 
 #define DLR_RENDERER_SERVICE_NAME "dleyna-renderer-service"
 
-static guint g_sig_id;
-
-static gboolean prv_quit_handler(GIOChannel *source, GIOCondition condition,
-				 gpointer user_data)
+static gboolean prv_quit_handler(gpointer user_data)
 {
 	dleyna_main_loop_quit();
-	g_sig_id = 0;
 
 	return FALSE;
 }
 
-static gboolean prv_init_signal_handler(sigset_t mask)
-{
-	gboolean retval = FALSE;
-	int fd = -1;
-	GIOChannel *channel = NULL;
-
-	fd = signalfd(-1, &mask, SFD_NONBLOCK);
-	if (fd == -1)
-		goto on_error;
-
-	channel = g_io_channel_unix_new(fd);
-	g_io_channel_set_close_on_unref(channel, TRUE);
-
-	if (g_io_channel_set_flags(channel, G_IO_FLAG_NONBLOCK, NULL) !=
-	    G_IO_STATUS_NORMAL)
-		goto on_error;
-
-	if (g_io_channel_set_encoding(channel, NULL, NULL) !=
-	    G_IO_STATUS_NORMAL)
-		goto on_error;
-
-	g_sig_id = g_io_add_watch(channel, G_IO_IN | G_IO_PRI,
-				  prv_quit_handler,
-				  NULL);
-
-	retval = TRUE;
-
-on_error:
-
-	if (channel)
-		g_io_channel_unref(channel);
-
-	return retval;
-}
-
 int main(int argc, char *argv[])
 {
-	sigset_t mask;
-	int retval = 1;
+	int retval;
 
-	sigemptyset(&mask);
-	sigaddset(&mask, SIGTERM);
-	sigaddset(&mask, SIGINT);
-
-	if (sigprocmask(SIG_BLOCK, &mask, NULL) == -1)
-		goto out;
-
-	if (!prv_init_signal_handler(mask))
-		goto out;
+	g_unix_signal_add (SIGTERM, prv_quit_handler, NULL);
+	g_unix_signal_add (SIGINT, prv_quit_handler, NULL);
 
 	retval = dleyna_main_loop_start(DLR_RENDERER_SERVICE_NAME,
 					dleyna_control_point_get_renderer(),
 					NULL);
-
-out:
-
-	if (g_sig_id)
-		(void) g_source_remove(g_sig_id);
 
 	return retval;
 }


### PR DESCRIPTION
Make use of GLib signal handling instead of signalfd.  This has several
advantages:
- signalfd is not well-defined in processes where you do not control
  the creation of all threads (and in particular their signal mask).
  GLib implicitly creates threads, so you should not use signalfd here.
- signalfd is not portable which prevents dleyna-renderer from building
  on non-Linux systems (which it otherwise would)
- using the GLib API gives a substantial reduction in complicated code
