### PR TITLE
[Device] Free dlna class strings after use

### DIFF
--- a/libdleyna/renderer/device.c
+++ b/libdleyna/renderer/device.c
@@ -1139,11 +1139,7 @@ static GVariant *prv_update_prop_dlna_device_classes(GUPnPDeviceInfo *proxy,
 	g_hash_table_insert(props, DLR_INTERFACE_PROP_DLNA_DEVICE_CLASSES,
 			    retval);
 
-	/* TODO: We should actually be calling g_list_free_full here but the
-	   strings in dlna_classes are allocated by libxml and not glib.  So
-	   until this is fixed we're stuck with this.  */
-
-	g_list_free(dlna_classes);
+	g_list_free_full(dlna_classes, g_free);
 
 on_exit:
 


### PR DESCRIPTION
Ownership of strings in the GList that
gupnp_device_info_list_dlna_device_class_identifier () returns is
fully transferred since GUPnP 0.20.4. Free the strings after use.

Fixes #129.

Signed-off-by: Jussi Kukkonen jussi.kukkonen@intel.com
