### PR TITLE
Ensure that g_context.watchers has a valid value

### DIFF
--- a/libdleyna/renderer/server.c
+++ b/libdleyna/renderer/server.c
@@ -688,7 +688,9 @@ static void prv_remove_client(const gchar *name)
 
 	dlr_upnp_lost_client(g_context.upnp, name);
 
-	g_context.watchers--;
+	if (g_context.watchers > 0)
+		g_context.watchers--;
+
 	if (g_context.watchers == 0)
 		if (!dleyna_settings_is_never_quit(g_context.settings))
 			dleyna_task_processor_set_quitting(g_context.processor);


### PR DESCRIPTION
Since g_context.watchers is an unsigned integer, we should be careful
not to decrement it below zero. This can happen if the service is
spawned as a result of the following command:
$ gdbus call \
    --session \
    --dest com.intel.dleyna-renderer \
    --object-path /com/intel/dLeynaRenderer \
    --method com.intel.dLeynaRenderer.Manager.Release