### PR TITLE
Add headers even if no profile detected

### DIFF
--- a/libdleyna/renderer/host-service.c
+++ b/libdleyna/renderer/host-service.c
@@ -103,6 +103,12 @@ static void prv_compute_mime_and_dlna_header(const gchar *filename,
 		goto on_error;
 	}
 
+	operation = GUPNP_DLNA_OPERATION_RANGE;
+	g_string_append_printf(header, "DLNA.ORG_OP=%.2x;", operation);
+
+	conversion = GUPNP_DLNA_CONVERSION_NONE;
+	g_string_append_printf(header, "DLNA.ORG_CI=%.2x;", conversion);
+
 	profile = gupnp_dlna_profile_guesser_guess_profile_sync(guesser,
 								uri,
 								5000,
@@ -124,12 +130,6 @@ static void prv_compute_mime_and_dlna_header(const gchar *filename,
 	profile_name = gupnp_dlna_profile_get_name(profile);
 	if (profile_name != NULL)
 		g_string_append_printf(header, "DLNA.ORG_PN=%s;", profile_name);
-
-	operation = GUPNP_DLNA_OPERATION_RANGE;
-	g_string_append_printf(header, "DLNA.ORG_OP=%.2x;", operation);
-
-	conversion = GUPNP_DLNA_CONVERSION_NONE;
-	g_string_append_printf(header, "DLNA.ORG_CI=%.2x;", conversion);
 
 	dlna_mime_type = gupnp_dlna_profile_get_mime(profile);
 	if (dlna_mime_type != NULL) {


### PR DESCRIPTION
Sometimes a profile can't be detected, but the renderer can make a good
guess. For example, if a movie can't be detected, some renderers can show
it if they have a range operation sent. This change adds the operation
range and conversion headers.

I have tested this with a Samsung LN37D550 TV.