### PR TITLE
Avoid any attempts to delete the same dlr_upnp_t twice

### DIFF
--- a/libdleyna/renderer/server.c
+++ b/libdleyna/renderer/server.c
@@ -723,6 +723,7 @@ static void prv_control_point_stop_service(void)
 	if (g_context.upnp) {
 		dlr_upnp_unsubscribe(g_context.upnp);
 		dlr_upnp_delete(g_context.upnp);
+		g_context.upnp = NULL;
 	}
 
 	if (g_context.connection) {


### PR DESCRIPTION
It is a good idea to NULLify g_context.upnp to avoid any possibility of
a crash due to double-free.

https://bugzilla.redhat.com/show_bug.cgi?id=1251366